### PR TITLE
Add Joystick type core option

### DIFF
--- a/libretro.c
+++ b/libretro.c
@@ -512,6 +512,13 @@ void retro_run(void)
       printf("w:%d h:%d a:%f\n",retrow,retroh,(float)(4/3));
       CHANGEAV=0;
    }
+   
+   bool updated = false;
+   
+   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE_UPDATE, &updated) && updated)
+   {
+      update_variables();
+   }
 
    update_input();
 

--- a/libretro.c
+++ b/libretro.c
@@ -12,7 +12,6 @@ char slash = '\\';
 char slash = '/';
 #endif
 
-#define RETRO_DEVICE_CPSF_MD	RETRO_DEVICE_SUBCLASS(RETRO_DEVICE_JOYPAD, 0)
 #define SOUNDRATE 44100.0
 #define SNDSZ 795
 
@@ -31,7 +30,7 @@ bool opt_analog;
 int retrow=800;
 int retroh=600;
 int CHANGEAV=0;
-int INPUT_DEVICE;
+int JOY_TYPE;
 
 int pauseg=0;
 
@@ -243,24 +242,12 @@ void retro_set_environment(retro_environment_t cb)
    environ_cb = cb;
 
    struct retro_variable variables[] = {
-      {
-         "px68k_analog","Use Analog; OFF|ON",
-      },
+      { "px68k_analog" , "Use Analog; OFF|ON" },
+      { "px68k_joypad" , "Joypad Type; Default (2 Buttons)|CPSF-MD (6 Buttons)|CPSF-SFC (8 Buttons)" },
       { NULL, NULL },
    };
 
-   static const struct retro_controller_description port_1[] = {
-      { "ATARI (Standard)", RETRO_DEVICE_JOYPAD },
-      { "CPSF-MD (6-buttons)", RETRO_DEVICE_CPSF_MD },
-   };
-
-   static const struct retro_controller_info ports[] = {
-      { port_1, 2 },
-      { 0, 0, 0 }
-   };
-
    cb(RETRO_ENVIRONMENT_SET_VARIABLES, variables);
-   environ_cb(RETRO_ENVIRONMENT_SET_CONTROLLER_INFO, (void*)ports);
 
 }
 
@@ -281,6 +268,19 @@ static void update_variables(void)
          opt_analog = true;
 
       fprintf(stderr, "[libretro-test]: Analog: %s.\n",opt_analog?"ON":"OFF");
+   }
+   
+   var.key = "px68k_joypad";
+   var.value = NULL;
+
+   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
+   {
+      if (strcmp(var.value, "Default (2 Buttons)") == 0)
+         JOY_TYPE = 0;
+      else if (strcmp(var.value, "CPSF-MD (6 Buttons)") == 0)
+         JOY_TYPE = 1;
+      else if (strcmp(var.value, "CPSF-SFC (8 Buttons)") == 0)
+         JOY_TYPE = 2;
    }
 }
 
@@ -334,14 +334,8 @@ void update_geometry(void)
 
 void retro_set_controller_port_device(unsigned port, unsigned device)
 {
-    switch (device) {
-		case RETRO_DEVICE_JOYPAD:
-			INPUT_DEVICE = 0;
-			break;
-		case RETRO_DEVICE_CPSF_MD:
-			INPUT_DEVICE = 1;
-			break;
-	}
+	(void)port;
+	(void)device;
 }
 
 size_t retro_serialize_size(void)

--- a/libretro/joystick.c
+++ b/libretro/joystick.c
@@ -8,7 +8,7 @@
 
 #include "libretro.h"
 extern retro_input_state_t input_state_cb;
-extern int INPUT_DEVICE;
+extern int JOY_TYPE;
 
 #ifndef MAX_BUTTON
 #define MAX_BUTTON 32
@@ -94,22 +94,36 @@ void FASTCALL Joystick_Update(int is_menu, int key)
 	int num = 0; //xxx only joy1
 	static BYTE pre_ret0 = 0xff, pre_mret0 = 0xff;
 
-	switch (INPUT_DEVICE) {
-	case 1: //6-button
+	switch (JOY_TYPE) {
+	case 2: //8-buttons CPSF-SFC
+		if (input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_RIGHT))ret0 ^= JOY_RIGHT;
+		if (input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_LEFT))ret0 ^= JOY_LEFT;
+		if (input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_UP) )ret0 ^= JOY_UP;
+		if (input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_DOWN))ret0 ^= JOY_DOWN;
+		if (input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_A) )ret0 ^= JOY_TRG2;
+		if (input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_B) )ret0 ^= JOY_TRG1;
+		if (input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_SELECT))ret1 ^= JOY_TRG7;
+		if (input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_START) )ret1 ^= JOY_TRG6;
+		if (input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_X) )ret1 ^= JOY_TRG3;
+		if (input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_Y) )ret1 ^= JOY_TRG4;
+		if (input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_L))ret1 ^= JOY_TRG8;
+		if (input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_R) )ret1 ^= JOY_TRG5;
+		break;
+	case 1: //6-buttons CPSF-MD + start & select combos
 		if (input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_RIGHT))ret0 ^= JOY_RIGHT;
 		if (input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_LEFT))ret0 ^= JOY_LEFT;
 		if (input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_UP) )ret0 ^= JOY_UP;
 		if (input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_DOWN))ret0 ^= JOY_DOWN;
 		if (input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_A) )ret0 ^= JOY_TRG1;		// Low-Kick
 		if (input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_B) )ret0 ^= JOY_TRG2;		// Mid-Kick
-		if (input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_SELECT))ret0 ^= JOY_TRG8;
-		if (input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_START) )ret0 ^= JOY_TRG7;
+		if (input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_SELECT))ret0 ^= (JOY_LEFT | JOY_RIGHT); //combo instead of unmapped
+		if (input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_START) )ret0 ^= (JOY_UP | JOY_DOWN); //combo instead of unmapped
 		if (input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_X) ) ret1 ^= JOY_TRG4; 	// Low-Punch
 		if (input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_Y) )ret1 ^= JOY_TRG3;		// Mid-Punch
 		if (input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_L))ret1 ^= JOY_TRG5;		// High-Punch
 		if (input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_R) )ret1 ^= JOY_TRG8;		// High-Kick
 		break;
-	case 0: //default controller
+	case 0: //2-buttons default controller
 	default:
 		if (input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_RIGHT))ret0 ^= JOY_RIGHT;
 		if (input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_LEFT))ret0 ^= JOY_LEFT;
@@ -117,12 +131,12 @@ void FASTCALL Joystick_Update(int is_menu, int key)
 		if (input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_DOWN))ret0 ^= JOY_DOWN;
 		if (input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_A) )ret0 ^= JOY_TRG1;
 		if (input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_B) )ret0 ^= JOY_TRG2;
-		if (input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_SELECT))ret0 ^= (JOY_LEFT | JOY_RIGHT);	// [RUN]JOY_TRG3;
-		if (input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_START) )ret0 ^= (JOY_UP | JOY_DOWN);	// [SELECT]JOY_TRG4;
-		if (input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_X) )ret0 ^= JOY_TRG1;//JOY_TRG5;
-		if (input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_Y) )ret0 ^= JOY_TRG2;//JOY_TRG6;
-		if (input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_L))ret0 ^= JOY_TRG1;//JOY_TRG7;
-		if (input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_R) )ret0 ^= JOY_TRG2;//JOY_TRG8;
+		if (input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_SELECT))ret0 ^= (JOY_LEFT | JOY_RIGHT);
+		if (input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_START) )ret0 ^= (JOY_UP | JOY_DOWN);
+		if (input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_X) )ret0 ^= JOY_TRG1;
+		if (input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_Y) )ret0 ^= JOY_TRG2;
+		if (input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_L))ret0 ^= JOY_TRG1;
+		if (input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_R) )ret0 ^= JOY_TRG2;
 		break;
 	}
 

--- a/libretro/joystick.c
+++ b/libretro/joystick.c
@@ -129,8 +129,8 @@ void FASTCALL Joystick_Update(int is_menu, int key)
 		if (input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_LEFT))ret0 ^= JOY_LEFT;
 		if (input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_UP) )ret0 ^= JOY_UP;
 		if (input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_DOWN))ret0 ^= JOY_DOWN;
-		if (input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_A) )ret0 ^= JOY_TRG1;
-		if (input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_B) )ret0 ^= JOY_TRG2;
+		if (input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_A) )ret0 ^= JOY_TRG2;
+		if (input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_B) )ret0 ^= JOY_TRG1;
 		if (input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_SELECT))ret0 ^= (JOY_LEFT | JOY_RIGHT);
 		if (input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_START) )ret0 ^= (JOY_UP | JOY_DOWN);
 		if (input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_X) )ret0 ^= JOY_TRG1;


### PR DESCRIPTION
-Default 2 buttons

-CPSF-MD: 6 buttons Megadrive stick + up/down and left-right combos on start and select as they are not mapped. Maps directly to SF2' "SNES alike" (strong attacks on L & R)
Original stick mapping is ABC XYZ.

-CPSF-SFC: 8 buttons Super Famicom Joystick with a strange button placement YBA LXR.
Mapped it to corresponding Retropad letters to avoid confusion when trying to change keys in-game. 
(and 2 buttons games would work with retro_L and retro_A with the original mapping)

For 2 buttons default, changed A for jump, B for shoot/run.
Kept X & Y inverted so you can play SNES style vertically with A & X or B & Y in 2 different styles.