### PR TITLE
android: buildfix

### DIFF
--- a/libretro.c
+++ b/libretro.c
@@ -324,7 +324,7 @@ void retro_set_controller_descriptors()
    }
    else if (joypad1 || joypad2)
    {
-      for (unsigned i = 0; i < size; i++)
+      for (i = 0; i < size; i++)
       {
          if (joypad1)
             inputDescriptors[i] = inputDescriptorsP1[i];


### PR DESCRIPTION
/home/buildbot/buildbot/android/libretro-px68k/libretro/jni/../../libretro.c:327:7: error: 'for' loop initial declarations are only allowed in C99 or C11 mode
       for (unsigned i = 0; i < size; i++)