### PR TITLE
Fix wrong strncpy() size calculation of win32api/dosio.c

### DIFF
--- a/win32api/dosio.c
+++ b/win32api/dosio.c
@@ -220,7 +220,7 @@ LPSTR
 file_getcd(LPSTR filename)
 {
 
-	strncpy(curfilep, filename, curfilep - curpath);
+	strncpy(curfilep, filename, MAX_PATH - (curfilep - curpath));
 	return curpath;
 }
 
@@ -228,7 +228,7 @@ FILEH
 file_open_c(LPSTR filename)
 {
 
-	strncpy(curfilep, filename, curfilep - curpath);
+	strncpy(curfilep, filename, MAX_PATH - (curfilep - curpath));
 	return file_open(curpath);
 }
 
@@ -236,7 +236,7 @@ FILEH
 file_create_c(LPSTR filename, int ftype)
 {
 
-	strncpy(curfilep, filename, curfilep - curpath);
+	strncpy(curfilep, filename, MAX_PATH - (curfilep - curpath));
 	return file_create(curpath, ftype);
 }
 
@@ -244,7 +244,7 @@ short
 file_attr_c(LPSTR filename)
 {
 
-	strncpy(curfilep, filename, curfilep - curpath);
+	strncpy(curfilep, filename, MAX_PATH - (curfilep - curpath));
 	return file_attr(curpath);
 }
 


### PR DESCRIPTION
strncpy() max size calculation on win32api/dosio.c is wrong.

For example in case curpath is ".//keropi/" (10 byte length), strncpy() append filename only 10byte.
It means reading BIOS ROM "iplrom.dat" will be success ( curpath ".//keropi/iplrom.dat" will be generated ) however, reading BIOS ROM "iplrom30.dat" will be fail ( curpath ".//keropi/iplrom30.d" will be generated ).

And if length of curpath is longher than `0.5*(MAX_PATH+32)` byte, strncpy() shall run over curpath buffer.
strncpy() max size must be smaller than `MAX_PATH + 32 - (curfilep - curpath)`. Considering 32 byte as safe margin, correct max size will be `MAX_PATH - (curfilep - curpath)`.