### PR TITLE
Lag fix, Ram fix, joystick simplification.

### DIFF
--- a/libretro.c
+++ b/libretro.c
@@ -49,8 +49,7 @@ int CHANGEAV = 0;
 int CHANGEAV_TIMING = 0; /* Separate change of geometry from change of refresh rate */
 int VID_MODE = 1;
 float FRAMERATE = MODE_HIGH;
-int JOY1_TYPE;
-int JOY2_TYPE;
+int JOY_TYPE[2] = {0}; /* Set controller type for each player to use */
 int clockmhz = 10;
 DWORD ram_size;
 int pcm_vol, opm_vol;
@@ -558,7 +557,26 @@ void retro_set_environment(retro_environment_t cb)
 
 static void update_variables(void)
 {
+   int i;
+   char key[256];
    struct retro_variable var = {0};
+
+   strcpy(key, "px68k_joytype");
+   var.key = key;
+   for (i = 0; i < 2; i++)
+   {
+      key[strlen("px68k_joytype")] = '1' + i;
+      var.value = NULL;
+      if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value) {
+         if (!(strcmp(var.value, "Default (2 Buttons)"))) {
+            JOY_TYPE[i] = 0;
+         } else if (!(strcmp(var.value, "CPSF-MD (8 Buttons)"))) {
+            JOY_TYPE[i] = 1;
+         } else if (!(strcmp(var.value, "CPSF-SFC (8 Buttons)"))) {
+            JOY_TYPE[i] = 2;
+         }
+      }
+   }
 
    var.key = "px68k_cpuspeed";
    var.value = NULL;
@@ -589,29 +607,31 @@ static void update_variables(void)
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
    {
       if (strcmp(var.value, "1MB") == 0)
-         ram_size = 0x100000;
+         ram_size = 1;
       else if (strcmp(var.value, "2MB") == 0)
-         ram_size = 0x200000;
+         ram_size = 2;
       else if (strcmp(var.value, "3MB") == 0)
-         ram_size = 0x300000;
+         ram_size = 3;
       else if (strcmp(var.value, "4MB") == 0)
-         ram_size = 0x400000;
+         ram_size = 4;
       else if (strcmp(var.value, "5MB") == 0)
-         ram_size = 0x500000;
+         ram_size = 5;
       else if (strcmp(var.value, "6MB") == 0)
-         ram_size = 0x600000;
+         ram_size = 6;
       else if (strcmp(var.value, "7MB") == 0)
-         ram_size = 0x700000;
+         ram_size = 7;
       else if (strcmp(var.value, "8MB") == 0)
-         ram_size = 0x800000;
+         ram_size = 8;
       else if (strcmp(var.value, "9MB") == 0)
-         ram_size = 0x900000;
+         ram_size = 9;
       else if (strcmp(var.value, "10MB") == 0)
-         ram_size = 0xa00000;
+         ram_size = 10;
       else if (strcmp(var.value, "11MB") == 0)
-         ram_size = 0xb00000;
+         ram_size = 11;
       else if (strcmp(var.value, "12MB") == 0)
-         ram_size = 0xc00000;
+         ram_size = 12;
+
+      ram_size <<= 20; /* convert to bytes */
    }
 
    var.key = "px68k_analog";
@@ -626,32 +646,6 @@ static void update_variables(void)
          opt_analog = true;
 
       //fprintf(stderr, "[libretro-test]: Analog: %s.\n",opt_analog?"ON":"OFF");
-   }
-
-   var.key = "px68k_joytype1";
-   var.value = NULL;
-
-   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
-   {
-      if (strcmp(var.value, "Default (2 Buttons)") == 0)
-         JOY1_TYPE = 0;
-      else if (strcmp(var.value, "CPSF-MD (8 Buttons)") == 0)
-         JOY1_TYPE = 1;
-      else if (strcmp(var.value, "CPSF-SFC (8 Buttons)") == 0)
-         JOY1_TYPE = 2;
-   }
-
-   var.key = "px68k_joytype2";
-   var.value = NULL;
-
-   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
-   {
-      if (strcmp(var.value, "Default (2 Buttons)") == 0)
-         JOY2_TYPE = 0;
-      else if (strcmp(var.value, "CPSF-MD (8 Buttons)") == 0)
-         JOY2_TYPE = 1;
-      else if (strcmp(var.value, "CPSF-SFC (8 Buttons)") == 0)
-         JOY2_TYPE = 2;
    }
 
    var.key = "px68k_adpcm_vol";

--- a/libretro/joystick.c
+++ b/libretro/joystick.c
@@ -8,8 +8,7 @@
 
 #include "libretro.h"
 extern retro_input_state_t input_state_cb;
-extern int JOY1_TYPE;
-extern int JOY2_TYPE;
+extern int JOY_TYPE[2];
 
 #ifndef MAX_BUTTON
 #define MAX_BUTTON 32
@@ -96,98 +95,47 @@ void FASTCALL Joystick_Update(int is_menu, int key, int port)
 	BYTE mret0 = 0xff, mret1 = 0xff;
 	static BYTE pre_ret0 = 0xff, pre_mret0 = 0xff;
 
-	if ( port == 0 && joypad1){
-		switch (JOY1_TYPE) {
-		case 2: //8-buttons CPSF-SFC
-			if (input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_RIGHT))ret0 ^= JOY_RIGHT;
-			if (input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_LEFT))ret0 ^= JOY_LEFT;
-			if (input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_UP) )ret0 ^= JOY_UP;
-			if (input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_DOWN))ret0 ^= JOY_DOWN;
-			if (input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_A) )ret0 ^= JOY_TRG2;
-			if (input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_B) )ret0 ^= JOY_TRG1;
-			if (input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_SELECT))ret1 ^= JOY_TRG7;
-			if (input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_START) )ret1 ^= JOY_TRG6;
-			if (input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_X) )ret1 ^= JOY_TRG3;
-			if (input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_Y) )ret1 ^= JOY_TRG4;
-			if (input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_L))ret1 ^= JOY_TRG8;
-			if (input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_R) )ret1 ^= JOY_TRG5;
-			break;
-		case 1: //8-buttons CPSF-MD
-			if (input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_RIGHT))ret0 ^= JOY_RIGHT;
-			if (input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_LEFT))ret0 ^= JOY_LEFT;
-			if (input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_UP) )ret0 ^= JOY_UP;
-			if (input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_DOWN))ret0 ^= JOY_DOWN;
-			if (input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_A) )ret0 ^= JOY_TRG1;	// Low-Kick
-			if (input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_B) )ret0 ^= JOY_TRG2;	// Mid-Kick
-			if (input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_SELECT))ret1 ^= JOY_TRG7;	// Mode
-			if (input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_START) )ret1 ^= JOY_TRG6; 	// Start
-			if (input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_X) ) ret1 ^= JOY_TRG4; 	// Low-Punch
-			if (input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_Y) )ret1 ^= JOY_TRG3;	// Mid-Punch
-			if (input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_L))ret1 ^= JOY_TRG5;	// High-Punch
-			if (input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_R) )ret1 ^= JOY_TRG8;	// High-Kick
-			break;
-		case 0: //2-buttons default controller
-		default:
-			if (input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_RIGHT))ret0 ^= JOY_RIGHT;
-			if (input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_LEFT))ret0 ^= JOY_LEFT;
-			if (input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_UP) )ret0 ^= JOY_UP;
-			if (input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_DOWN))ret0 ^= JOY_DOWN;
-			if (input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_A) )ret0 ^= (Config.VbtnSwap ? JOY_TRG1 : JOY_TRG2);
-			if (input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_B) )ret0 ^= (Config.VbtnSwap ? JOY_TRG2 : JOY_TRG1);
-			if (input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_SELECT))ret0 ^= (JOY_LEFT | JOY_RIGHT);
-			if (input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_START) )ret0 ^= (JOY_UP | JOY_DOWN);
-			if (input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_X) )ret0 ^= (Config.VbtnSwap ? JOY_TRG2 : JOY_TRG1);
-			if (input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_Y) )ret0 ^= (Config.VbtnSwap ? JOY_TRG1 : JOY_TRG2);
-			//if (input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_L))ret0 ^= JOY_TRG1;
-			//if (input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_R) )ret0 ^= JOY_TRG2;
-			break;
-		}
-	} else if (port == 1 && joypad2) {
-		switch (JOY2_TYPE) {
-		case 2: //8-buttons CPSF-SFC
-			if (input_state_cb(1, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_RIGHT))ret0 ^= JOY_RIGHT;
-			if (input_state_cb(1, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_LEFT))ret0 ^= JOY_LEFT;
-			if (input_state_cb(1, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_UP) )ret0 ^= JOY_UP;
-			if (input_state_cb(1, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_DOWN))ret0 ^= JOY_DOWN;
-			if (input_state_cb(1, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_A) )ret0 ^= JOY_TRG2;
-			if (input_state_cb(1, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_B) )ret0 ^= JOY_TRG1;
-			if (input_state_cb(1, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_SELECT))ret1 ^= JOY_TRG7;
-			if (input_state_cb(1, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_START) )ret1 ^= JOY_TRG6;
-			if (input_state_cb(1, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_X) )ret1 ^= JOY_TRG3;
-			if (input_state_cb(1, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_Y) )ret1 ^= JOY_TRG4;
-			if (input_state_cb(1, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_L))ret1 ^= JOY_TRG8;
-			if (input_state_cb(1, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_R) )ret1 ^= JOY_TRG5;
-			break;
-		case 1: //8-buttons CPSF-MD
-			if (input_state_cb(1, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_RIGHT))ret0 ^= JOY_RIGHT;
-			if (input_state_cb(1, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_LEFT))ret0 ^= JOY_LEFT;
-			if (input_state_cb(1, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_UP) )ret0 ^= JOY_UP;
-			if (input_state_cb(1, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_DOWN))ret0 ^= JOY_DOWN;
-			if (input_state_cb(1, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_A) )ret0 ^= JOY_TRG1;	// Low-Kick
-			if (input_state_cb(1, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_B) )ret0 ^= JOY_TRG2;	// Mid-Kick
-			if (input_state_cb(1, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_SELECT))ret1 ^= JOY_TRG7; 	// Mode
-			if (input_state_cb(1, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_START) )ret1 ^= JOY_TRG6; 	// Start
-			if (input_state_cb(1, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_X) ) ret1 ^= JOY_TRG4; 	// Low-Punch
-			if (input_state_cb(1, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_Y) )ret1 ^= JOY_TRG3;	// Mid-Punch
-			if (input_state_cb(1, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_L))ret1 ^= JOY_TRG5;	// High-Punch
-			if (input_state_cb(1, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_R) )ret1 ^= JOY_TRG8;	// High-Kick
-			break;
-		case 0: //2-buttons default controller
-		default:
-			if (input_state_cb(1, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_RIGHT))ret0 ^= JOY_RIGHT;
-			if (input_state_cb(1, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_LEFT))ret0 ^= JOY_LEFT;
-			if (input_state_cb(1, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_UP) )ret0 ^= JOY_UP;
-			if (input_state_cb(1, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_DOWN))ret0 ^= JOY_DOWN;
-			if (input_state_cb(1, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_A) )ret0 ^= (Config.VbtnSwap ? JOY_TRG1 : JOY_TRG2);
-			if (input_state_cb(1, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_B) )ret0 ^= (Config.VbtnSwap ? JOY_TRG2 : JOY_TRG1);
-			if (input_state_cb(1, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_SELECT))ret0 ^= (JOY_LEFT | JOY_RIGHT);
-			if (input_state_cb(1, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_START) )ret0 ^= (JOY_UP | JOY_DOWN);
-			if (input_state_cb(1, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_X) )ret0 ^= (Config.VbtnSwap ? JOY_TRG2 : JOY_TRG1);
-			if (input_state_cb(1, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_Y) )ret0 ^= (Config.VbtnSwap ? JOY_TRG1 : JOY_TRG2);
-			//if (input_state_cb(1, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_L))ret0 ^= JOY_TRG1;
-			//if (input_state_cb(1, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_R) )ret0 ^= JOY_TRG2;
-			break;
-		}
+	switch (JOY_TYPE[port]) {
+	case 0: //2-buttons default controller
+		if (input_state_cb(port, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_RIGHT))	ret0 ^= JOY_RIGHT;
+		if (input_state_cb(port, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_LEFT))	ret0 ^= JOY_LEFT;
+		if (input_state_cb(port, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_UP))		ret0 ^= JOY_UP;
+		if (input_state_cb(port, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_DOWN))	ret0 ^= JOY_DOWN;
+		if (input_state_cb(port, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_A) )		ret0 ^= (Config.VbtnSwap ? JOY_TRG1 : JOY_TRG2);
+		if (input_state_cb(port, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_B) )		ret0 ^= (Config.VbtnSwap ? JOY_TRG2 : JOY_TRG1);
+		if (input_state_cb(port, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_SELECT))	ret0 ^= (JOY_LEFT | JOY_RIGHT);
+		if (input_state_cb(port, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_START) )	ret0 ^= (JOY_UP | JOY_DOWN);
+		if (input_state_cb(port, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_X) )		ret0 ^= (Config.VbtnSwap ? JOY_TRG2 : JOY_TRG1);
+		if (input_state_cb(port, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_Y) )		ret0 ^= (Config.VbtnSwap ? JOY_TRG1 : JOY_TRG2);
+		break;
+	case 1: //8-buttons CPSF-MD
+		if (input_state_cb(port, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_RIGHT))	ret0 ^= JOY_RIGHT;
+		if (input_state_cb(port, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_LEFT))	ret0 ^= JOY_LEFT;
+		if (input_state_cb(port, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_UP))		ret0 ^= JOY_UP;
+		if (input_state_cb(port, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_DOWN))	ret0 ^= JOY_DOWN;
+		if (input_state_cb(port, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_A))		ret0 ^= JOY_TRG1;	// Low-Kick
+		if (input_state_cb(port, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_B))		ret0 ^= JOY_TRG2;	// Mid-Kick
+		if (input_state_cb(port, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_SELECT))	ret1 ^= JOY_TRG7;	// Mode
+		if (input_state_cb(port, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_START))	ret1 ^= JOY_TRG6; // Start
+		if (input_state_cb(port, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_X))		ret1 ^= JOY_TRG4; // Low-Punch
+		if (input_state_cb(port, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_Y))		ret1 ^= JOY_TRG3;	// Mid-Punch
+		if (input_state_cb(port, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_L))		ret1 ^= JOY_TRG5;	// High-Punch
+		if (input_state_cb(port, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_R))		ret1 ^= JOY_TRG8;	// High-Kick
+		break;
+	case 2: //8-buttons CPSF-SFC
+		if (input_state_cb(port, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_RIGHT))	ret0 ^= JOY_RIGHT;
+		if (input_state_cb(port, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_LEFT))	ret0 ^= JOY_LEFT;
+		if (input_state_cb(port, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_UP))		ret0 ^= JOY_UP;
+		if (input_state_cb(port, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_DOWN))	ret0 ^= JOY_DOWN;
+		if (input_state_cb(port, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_A))		ret0 ^= JOY_TRG2;
+		if (input_state_cb(port, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_B))		ret0 ^= JOY_TRG1;
+		if (input_state_cb(port, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_SELECT))	ret1 ^= JOY_TRG7;
+		if (input_state_cb(port, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_START))	ret1 ^= JOY_TRG6;
+		if (input_state_cb(port, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_X))		ret1 ^= JOY_TRG3;
+		if (input_state_cb(port, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_Y))		ret1 ^= JOY_TRG4;
+		if (input_state_cb(port, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_L))		ret1 ^= JOY_TRG8;
+		if (input_state_cb(port, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_R))		ret1 ^= JOY_TRG5;
+		break;
 	}
 
 	JoyDownState0 = ~(ret0 ^ pre_ret0) | ret0;
@@ -221,5 +169,3 @@ void reset_joy_upstate(void)
 {
 	JoyUpState0 = 0x00;
 }
-
-

--- a/libretro/winx68k.cpp
+++ b/libretro/winx68k.cpp
@@ -329,15 +329,18 @@ WinX68k_Cleanup(void)
 // -----------------------------------------------------------------------------------
 void WinX68k_Exec(void)
 {
-	if(!(Memory_ReadD(0xed0008)==ram_size)){
-		Memory_WriteB(0xe8e00d, 0x31);             // SRAM write permission
-		Memory_WriteD(0xed0008, ram_size);         // Define RAM amount
-	}
-	
 	//char *test = NULL;
 	int clk_total, clkdiv, usedclk, hsync, clk_next, clk_count, clk_line=0;
 	int KeyIntCnt = 0, MouseIntCnt = 0;
 	DWORD t_start = timeGetTime(), t_end;
+
+	if(!(Memory_ReadD(0xed0008)==ram_size)){
+		Memory_WriteB(0xe8e00d, 0x31);             // SRAM write permission
+		Memory_WriteD(0xed0008, ram_size);         // Define RAM amount
+	}
+
+	Joystick_Update(FALSE, -1, 0);
+	Joystick_Update(FALSE, -1, 1);
 
 	if ( Config.FrameRate != 7 ) {
 		DispFrame = (DispFrame+1)%Config.FrameRate;
@@ -538,9 +541,6 @@ void WinX68k_Exec(void)
 			GVRAM_FastClear();
 		}
 	}
-
-	Joystick_Update(FALSE, -1, 0);
-	Joystick_Update(FALSE, -1, 1);
 
 	FDD_SetFDInt();
 	if ( !DispFrame )

--- a/x68k/mem_wrap.c
+++ b/x68k/mem_wrap.c
@@ -255,10 +255,8 @@ wm_cnt(DWORD addr, BYTE val)
 {
 
 	addr &= 0x00ffffff;
-	if (addr < 0x00a00000) {	// RAM 10MB
+	if (addr < 0x00c00000) {	// Use RAM upto 12MB
 		MEM[addr ^ 1] = val;
-	} else if (addr < 0x00c00000) {
-		wm_buserr(addr, val);
 	} else if (addr < 0x00e00000) {
 		GVRAM_Write(addr, val);
 	} else {
@@ -422,11 +420,8 @@ rm_main(DWORD addr)
 	BYTE v;
 
 	addr &= 0x00ffffff;
-	if (addr < 0x00a00000) {	// RAM 10MB
+	if (addr < 0x00c00000) {	// Use RAM upto 12MB
 		v = MEM[addr ^ 1];
-	} else if (addr < 0x00c00000) {
-		rm_buserr(addr);
-		v = 0;
 	} else if (addr < 0x00e00000) {
 		v = GVRAM_Read(addr);
 	} else {


### PR DESCRIPTION
Stuff from retro-wertz.

-Recover 1 Frame of input lag.
-Simplify joypad type option and input handling
-Allow MEM map to use up to 12MB of memory

According to https://gamesx.com/wiki/doku.php?id=x68000:memory_map and Mame sources, x68000 should be able to use up to 12MB of memory. 
Current implementation only allowed 10MB max, selecting 11MB or 12MB resulted in bus errors.