### PR TITLE
fix-build: Do not force linker to `$(CC)`

### DIFF
--- a/Makefile.libretro
+++ b/Makefile.libretro
@@ -287,7 +287,7 @@ else
 	LD = link.exe
 endif
 else
-	LD = $(CC)
+	LD = $(CXX)
 endif
 
 all: $(TARGET)


### PR DESCRIPTION
* This core has a mixed C/C++ codebase, therefore use `$(CXX)` as linker

Currently the builds are broken after recent commit 1848262