### PR TITLE
fix-buildbot: Allow `platform` to be matched partially to `unix` instead of exactly

### DIFF
--- a/Makefile.libretro
+++ b/Makefile.libretro
@@ -47,7 +47,7 @@ TARGET_NAME := px68k
 ENDIANNESS_DEFINES :=
 CORE_DIR := .
 
-ifeq ($(platform), unix)
+ifneq (,$(findstring unix,$(platform)))
 	CFLAGS = -g -O2 
 	CXXFLAGS = -g -O2  -fno-merge-constants 
 	TARGET := $(TARGET_NAME)_libretro.so


### PR DESCRIPTION
* For `linux-arm7neonhf`, buildbot uses `platform=unix-armv7-hardfloat-neon` instead of `platform=unix`

Buildbot is currently failing for the `linux-arm7neonhf` target because the Makefile is incorrectly trying to match `platform` to exactly `unix` instead of partially. This PR fixes the issue and the build works now.

Tested build on Linux, ARM and Windows.
Ref: http://p.0bl.net/83594