### PR TITLE
2MB default RAM size

### DIFF
--- a/libretro_core_options.h
+++ b/libretro_core_options.h
@@ -101,7 +101,7 @@ struct retro_core_option_definition option_defs_us[] = {
          { "12MB", NULL },
          { NULL, NULL},
       },
-      "1MB"
+      "2MB"
    },
    {
       "px68k_analog",


### PR DESCRIPTION
Most games won't run with 1MB and will display an issue in Japanese.
Better have it set to 2 by default.