### PR TITLE
Joy1 select button key mapping (jfroco)

### DIFF
--- a/libretro.c
+++ b/libretro.c
@@ -42,8 +42,8 @@ const char *retro_content_directory;
 char retro_system_conf[512];
 char base_dir[MAX_PATH];
 
-char Core_Key_Sate[512];
-char Core_old_Key_Sate[512];
+char Core_Key_State[512];
+char Core_old_Key_State[512];
 
 bool joypad1, joypad2;
 
@@ -941,8 +941,8 @@ void retro_init(void)
 */
    update_variables();
 
-   memset(Core_Key_Sate, 0, 512);
-   memset(Core_old_Key_Sate, 0, sizeof(Core_old_Key_Sate));
+   memset(Core_Key_State, 0, 512);
+   memset(Core_old_Key_State, 0, sizeof(Core_old_Key_State));
 }
 
 void retro_deinit(void)

--- a/libretro.c
+++ b/libretro.c
@@ -9,6 +9,7 @@
 #include "libretro_core_options.h"
 #include "libretro/winx68k.h"
 #include "libretro/dswin.h"
+#include "libretro/keyboard.h"
 #include "libretro/prop.h"
 #include "fmgen/fmg_wrap.h"
 #include "x68k/adpcm.h"
@@ -322,7 +323,7 @@ int pre_main(const char *argv)
 
       Add_Option("px68k");
 
-      if (strlen(RPATH) >= strlen("hdf")) 
+      if (strlen(RPATH) >= strlen("hdf"))
       {
          if (!strcasecmp(&RPATH[strlen(RPATH) - strlen("hdf")], "hdf"))
          {
@@ -711,6 +712,33 @@ static void update_variables(void)
       else
          Config.MenuFontSize = 1;
    }
+
+   var.key = "px68k_joy1_select";
+   var.value = NULL;
+
+   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
+   {
+      if (!strcmp(var.value, "XF1"))
+         Config.joy1_select_mapping = KBD_XF1;
+      else if (!strcmp(var.value, "XF2"))
+         Config.joy1_select_mapping = KBD_XF2;
+      else if (!strcmp(var.value, "XF3"))
+         Config.joy1_select_mapping = KBD_XF3;
+      else if (!strcmp(var.value, "XF4"))
+         Config.joy1_select_mapping = KBD_XF4;
+      else if (!strcmp(var.value, "XF5"))
+         Config.joy1_select_mapping = KBD_XF5;
+      else if (!strcmp(var.value, "F1"))
+         Config.joy1_select_mapping = KBD_F1;
+      else if (!strcmp(var.value, "F2"))
+         Config.joy1_select_mapping = KBD_F2;
+      else if (!strcmp(var.value, "OPT1"))
+         Config.joy1_select_mapping = KBD_OPT1;
+      else if (!strcmp(var.value, "OPT2"))
+         Config.joy1_select_mapping = KBD_OPT2;
+      else
+         Config.joy1_select_mapping = 0;
+   }
 }
 
 void update_input(void)
@@ -944,7 +972,7 @@ void retro_run(void)
    }
 
    if (CHANGEAV || CHANGEAV_TIMING)
-   {     
+   {
       if (CHANGEAV_TIMING)
       {
          update_timing();

--- a/libretro/joystick.c
+++ b/libretro/joystick.c
@@ -108,7 +108,8 @@ void FASTCALL Joystick_Update(int is_menu, int key, int port)
 		if (input_state_cb(port, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_DOWN))	ret0 ^= JOY_DOWN;
 		if (input_state_cb(port, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_A) )		ret0 ^= (Config.VbtnSwap ? JOY_TRG1 : JOY_TRG2);
 		if (input_state_cb(port, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_B) )		ret0 ^= (Config.VbtnSwap ? JOY_TRG2 : JOY_TRG1);
-		if (input_state_cb(port, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_SELECT))	ret0 ^= (JOY_LEFT | JOY_RIGHT);
+		if (!Config.joy1_select_mapping)
+			if (input_state_cb(port, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_SELECT))	ret0 ^= (JOY_LEFT | JOY_RIGHT);
 		if (input_state_cb(port, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_START) )	ret0 ^= (JOY_UP | JOY_DOWN);
 		if (input_state_cb(port, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_X) )		ret0 ^= (Config.VbtnSwap ? JOY_TRG2 : JOY_TRG1);
 		if (input_state_cb(port, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_Y) )		ret0 ^= (Config.VbtnSwap ? JOY_TRG1 : JOY_TRG2);
@@ -120,7 +121,8 @@ void FASTCALL Joystick_Update(int is_menu, int key, int port)
 		if (input_state_cb(port, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_DOWN))	ret0 ^= JOY_DOWN;
 		if (input_state_cb(port, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_A))		ret0 ^= JOY_TRG1;	// Low-Kick
 		if (input_state_cb(port, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_B))		ret0 ^= JOY_TRG2;	// Mid-Kick
-		if (input_state_cb(port, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_SELECT))	ret1 ^= JOY_TRG7;	// Mode
+		if (!Config.joy1_select_mapping)
+			if (input_state_cb(port, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_SELECT))	ret1 ^= JOY_TRG7;	// Mode
 		if (input_state_cb(port, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_START))	ret1 ^= JOY_TRG6; // Start
 		if (input_state_cb(port, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_X))		ret1 ^= JOY_TRG4; // Low-Punch
 		if (input_state_cb(port, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_Y))		ret1 ^= JOY_TRG3;	// Mid-Punch
@@ -134,7 +136,8 @@ void FASTCALL Joystick_Update(int is_menu, int key, int port)
 		if (input_state_cb(port, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_DOWN))	ret0 ^= JOY_DOWN;
 		if (input_state_cb(port, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_A))		ret0 ^= JOY_TRG2;
 		if (input_state_cb(port, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_B))		ret0 ^= JOY_TRG1;
-		if (input_state_cb(port, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_SELECT))	ret1 ^= JOY_TRG7;
+		if (!Config.joy1_select_mapping)
+			if (input_state_cb(port, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_SELECT))	ret1 ^= JOY_TRG7;
 		if (input_state_cb(port, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_START))	ret1 ^= JOY_TRG6;
 		if (input_state_cb(port, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_X))		ret1 ^= JOY_TRG3;
 		if (input_state_cb(port, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_Y))		ret1 ^= JOY_TRG4;

--- a/libretro/keyboard.h
+++ b/libretro/keyboard.h
@@ -36,4 +36,16 @@ void Keyboard_skbd(void);
 int Keyboard_IsSwKeyboard(void);
 void Keyboard_ToggleSkbd(void);
 
+#define	RETROK_XFX	333
+/* https://gamesx.com/wiki/doku.php?id=x68000:keycodes */
+#define	KBD_XF1		0x55
+#define	KBD_XF2		0x56
+#define	KBD_XF3		0x57
+#define	KBD_XF4		0x58
+#define	KBD_XF5		0x59
+#define	KBD_F1		0x63
+#define	KBD_F2		0x64
+#define	KBD_OPT1	0x72
+#define	KBD_OPT2	0x73
+
 #endif //_winx68k_keyboard

--- a/libretro/prop.h
+++ b/libretro/prop.h
@@ -54,6 +54,7 @@ typedef struct
 	int NoWaitMode;
 	BYTE FrameRate;
 	int MenuFontSize; // font size of menu, 0 = normal, 1 = large
+	int joy1_select_mapping; /* used for keyboard to joypad map for P1 Select */
 } Win68Conf;
 
 extern Win68Conf Config;

--- a/libretro/winx68k.cpp
+++ b/libretro/winx68k.cpp
@@ -1,6 +1,6 @@
 #ifdef  __cplusplus
 extern "C" {
-#endif 
+#endif
 
 #include "common.h"
 #include "fileio.h"
@@ -299,7 +299,7 @@ WinX68k_Init(void)
 		ZeroMemory(MEM, MEM_SIZE);
 
 	if (MEM && FONT && IPL) {
-	  	m68000_init();  
+	  	m68000_init();
 		return TRUE;
 	} else
 		return FALSE;
@@ -367,7 +367,7 @@ void WinX68k_Exec(void)
 
 	clk_total = (clk_total*clockmhz)/10;
 	clkdiv = clockmhz;
-	
+
 //	if (Config.XVIMode == 1) {
 //		clk_total = (clk_total*16)/10;
 //		clkdiv = 16;
@@ -382,7 +382,7 @@ void WinX68k_Exec(void)
 		p6logd("CPU Clock: %d%s\n",clkdiv,"MHz");
 		p6logd("RAM Size: %ld%s\n",ram_size/1000000,"MB");
 		old_clkdiv = clkdiv;
-		old_ram_size = ram_size;	
+		old_ram_size = ram_size;
 	}
 
 	ICount += clk_total;
@@ -575,7 +575,7 @@ enum {menu_out, menu_enter, menu_in};
 int menu_mode = menu_out;
 #ifdef  __cplusplus
 };
-#endif 
+#endif
 extern "C" int pmain(int argc, char *argv[])
 {
 
@@ -707,7 +707,7 @@ extern "C" int pmain(int argc, char *argv[])
 		send_keycode(b, 2);\
 	else if ( !Core_Key_Sate[a] && Core_Key_Sate[a]!=Core_old_Key_Sate[a]  )\
 		send_keycode(b, 1);\
-}	
+}
 
 extern "C" void handle_retrok(){
 
@@ -844,7 +844,12 @@ extern "C" void handle_retrok(){
 //	KEYP(RETROK_MENU,0x55); //xf1
 //	KEYP(RETROK_KP_PERIOD,0x56); //xf2
 //	KEYP(RETROK_KP_PERIOD,0x57); //xf3
-//	KEYP(RETROK_KP_PERIOD,0x58); //xf4 
+
+	// only process kb_to_joypad map when its not zero, else button is used as joypad select mode
+	if (Config.joy1_select_mapping)
+		KEYP(RETROK_XFX, Config.joy1_select_mapping);
+
+//	KEYP(RETROK_KP_PERIOD,0x58); //xf4
 //	KEYP(RETROK_KP_PERIOD,0x59); //xf5
 //	KEYP(RETROK_KP_PERIOD,0x5a); //kana
 //	KEYP(RETROK_KP_PERIOD,0x5b); //romaji
@@ -904,9 +909,9 @@ extern "C" void exec_app_retro(){
 
 		int mouse_l    = input_state_cb(0, RETRO_DEVICE_MOUSE, 0, RETRO_DEVICE_ID_MOUSE_LEFT);
 		int mouse_r    = input_state_cb(0, RETRO_DEVICE_MOUSE, 0, RETRO_DEVICE_ID_MOUSE_RIGHT);
-		      
+
   	        if(mbL==0 && mouse_l){
-      			mbL=1;		
+      			mbL=1;
 			Mouse_Event(1,1.0,0);
 		}
    		else if(mbL==1 && !mouse_l)
@@ -915,7 +920,7 @@ extern "C" void exec_app_retro(){
 			Mouse_Event(1,0,0);
 		}
   	        if(mbR==0 && mouse_r){
-      			mbR=1;		
+      			mbR=1;
 			Mouse_Event(2,1.0,0);
 		}
    		else if(mbR==1 && !mouse_r)
@@ -929,8 +934,14 @@ extern "C" void exec_app_retro(){
    		for(i=0;i<320;i++)
       			Core_Key_Sate[i]=input_state_cb(0, RETRO_DEVICE_KEYBOARD, 0,i) ? 0x80: 0;
 
+      	Core_Key_Sate[RETROK_XFX] = 0;
+
    		if (input_state_cb(0, RETRO_DEVICE_JOYPAD,0, RETRO_DEVICE_ID_JOYPAD_L2))	//Joypad Key for Menu
 				Core_Key_Sate[RETROK_F12] = 0x80;
+
+		if (Config.joy1_select_mapping)
+			if (input_state_cb(0, RETRO_DEVICE_JOYPAD,0, RETRO_DEVICE_ID_JOYPAD_SELECT))	//Joypad Key for Mapping
+				Core_Key_Sate[RETROK_XFX] = 0x80;
 
 		if(memcmp( Core_Key_Sate,Core_old_Key_Sate , sizeof(Core_Key_Sate) ) )
 			handle_retrok();

--- a/libretro/winx68k.cpp
+++ b/libretro/winx68k.cpp
@@ -563,8 +563,8 @@ extern "C" {
 #include "libretro.h"
 
 extern retro_input_state_t input_state_cb;
-extern char Core_Key_Sate[512];
-extern char Core_old_Key_Sate[512];
+extern char Core_Key_State[512];
+extern char Core_old_Key_State[512];
 
 int mb1=0,mb2=0;
 extern int retrow,retroh,CHANGEAV;
@@ -703,9 +703,9 @@ extern "C" int pmain(int argc, char *argv[])
 }
 
 #define KEYP(a,b) {\
-	if(Core_Key_Sate[a] && Core_Key_Sate[a]!=Core_old_Key_Sate[a]  )\
+	if(Core_Key_State[a] && Core_Key_State[a]!=Core_old_Key_State[a]  )\
 		send_keycode(b, 2);\
-	else if ( !Core_Key_Sate[a] && Core_Key_Sate[a]!=Core_old_Key_Sate[a]  )\
+	else if ( !Core_Key_State[a] && Core_Key_State[a]!=Core_old_Key_State[a]  )\
 		send_keycode(b, 1);\
 }
 
@@ -715,25 +715,25 @@ extern "C" void handle_retrok(){
 	int key_shift,key_control,key_alt;
 
 	/* SHIFT STATE */
-	if ((Core_Key_Sate[RETROK_LSHIFT]) || (Core_Key_Sate[RETROK_RSHIFT]))
+	if ((Core_Key_State[RETROK_LSHIFT]) || (Core_Key_State[RETROK_RSHIFT]))
 		key_shift = 1;
 	else
 		key_shift = 0;
 
 	/* CONTROL STATE */
-	if ((Core_Key_Sate[RETROK_LCTRL]) || (Core_Key_Sate[RETROK_RCTRL]))
+	if ((Core_Key_State[RETROK_LCTRL]) || (Core_Key_State[RETROK_RCTRL]))
 		key_control = 1;
 	else
 		key_control = 0;
 
 	/* ALT STATE */
-	if ((Core_Key_Sate[RETROK_LALT]) || (Core_Key_Sate[RETROK_RALT]))
+	if ((Core_Key_State[RETROK_LALT]) || (Core_Key_State[RETROK_RALT]))
 		key_alt = 1;
 	else
 		key_alt = 0;
 #endif
 
-	if(Core_Key_Sate[RETROK_F12] && Core_Key_Sate[RETROK_F12]!=Core_old_Key_Sate[RETROK_F12]  )
+	if(Core_Key_State[RETROK_F12] && Core_Key_State[RETROK_F12]!=Core_old_Key_State[RETROK_F12]  )
 	{
 		if (menu_mode == menu_out) {
 			oldrw=retrow;oldrh=retroh;
@@ -750,7 +750,7 @@ extern "C" void handle_retrok(){
 	}
 
 #ifdef WIN68DEBUG
-	if(Core_Key_Sate[RETROK_F11] && Core_Key_Sate[RETROK_F11]!=Core_old_Key_Sate[RETROK_F11]  )
+	if(Core_Key_State[RETROK_F11] && Core_Key_State[RETROK_F11]!=Core_old_Key_State[RETROK_F11]  )
 		if (i == RETROK_F11) {
 			traceflag ^= 1;
 			printf("trace %s\n", (traceflag)?"on":"off");
@@ -932,37 +932,37 @@ extern "C" void exec_app_retro(){
   		int i;
 
    		for(i=0;i<320;i++)
-      			Core_Key_Sate[i]=input_state_cb(0, RETRO_DEVICE_KEYBOARD, 0,i) ? 0x80: 0;
+      			Core_Key_State[i]=input_state_cb(0, RETRO_DEVICE_KEYBOARD, 0,i) ? 0x80: 0;
 
-      	Core_Key_Sate[RETROK_XFX] = 0;
+      	Core_Key_State[RETROK_XFX] = 0;
 
    		if (input_state_cb(0, RETRO_DEVICE_JOYPAD,0, RETRO_DEVICE_ID_JOYPAD_L2))	//Joypad Key for Menu
-				Core_Key_Sate[RETROK_F12] = 0x80;
+				Core_Key_State[RETROK_F12] = 0x80;
 
 		if (Config.joy1_select_mapping)
 			if (input_state_cb(0, RETRO_DEVICE_JOYPAD,0, RETRO_DEVICE_ID_JOYPAD_SELECT))	//Joypad Key for Mapping
-				Core_Key_Sate[RETROK_XFX] = 0x80;
+				Core_Key_State[RETROK_XFX] = 0x80;
 
-		if(memcmp( Core_Key_Sate,Core_old_Key_Sate , sizeof(Core_Key_Sate) ) )
+		if(memcmp( Core_Key_State,Core_old_Key_State , sizeof(Core_Key_State) ) )
 			handle_retrok();
 
-   		memcpy(Core_old_Key_Sate,Core_Key_Sate , sizeof(Core_Key_Sate) );
+   		memcpy(Core_old_Key_State,Core_Key_State , sizeof(Core_Key_State) );
 
 		if (menu_mode != menu_out) {
 			int ret;
 
 			keyb_in = 0;
-			if (Core_Key_Sate[RETROK_RIGHT] || Core_Key_Sate[RETROK_PAGEDOWN])
+			if (Core_Key_State[RETROK_RIGHT] || Core_Key_State[RETROK_PAGEDOWN])
 				keyb_in |= JOY_RIGHT;
-			if (Core_Key_Sate[RETROK_LEFT] || Core_Key_Sate[RETROK_PAGEUP])
+			if (Core_Key_State[RETROK_LEFT] || Core_Key_State[RETROK_PAGEUP])
 				keyb_in |= JOY_LEFT;
-			if (Core_Key_Sate[RETROK_UP])
+			if (Core_Key_State[RETROK_UP])
 				keyb_in |= JOY_UP;
-			if (Core_Key_Sate[RETROK_DOWN])
+			if (Core_Key_State[RETROK_DOWN])
 				keyb_in |= JOY_DOWN;
-			if (Core_Key_Sate[RETROK_z] || Core_Key_Sate[RETROK_RETURN])
+			if (Core_Key_State[RETROK_z] || Core_Key_State[RETROK_RETURN])
 				keyb_in |= JOY_TRG1;
-			if (Core_Key_Sate[RETROK_x] || Core_Key_Sate[RETROK_BACKSPACE])
+			if (Core_Key_State[RETROK_x] || Core_Key_State[RETROK_BACKSPACE])
 				keyb_in |= JOY_TRG2;
 
 			Joystick_Update(TRUE, menu_key_down, 0);

--- a/libretro_core_options.h
+++ b/libretro_core_options.h
@@ -61,7 +61,7 @@ struct retro_core_option_definition option_defs_us[] = {
       {
          { "normal", NULL },
          { "large",  NULL },
-         { NULL, NULL},
+         { NULL,     NULL },
       },
       "normal"
    },
@@ -78,7 +78,7 @@ struct retro_core_option_definition option_defs_us[] = {
          { "100Mhz (OC)", NULL },
          { "150Mhz (OC)", NULL },
          { "200Mhz (OC)", NULL },
-         { NULL, NULL},
+         { NULL,          NULL },
       },
       "10Mhz"
    },
@@ -99,7 +99,7 @@ struct retro_core_option_definition option_defs_us[] = {
          { "10MB", NULL },
          { "11MB", NULL },
          { "12MB", NULL },
-         { NULL, NULL},
+         { NULL,   NULL },
       },
       "2MB"
    },
@@ -110,7 +110,7 @@ struct retro_core_option_definition option_defs_us[] = {
       {
          { "disabled", NULL },
          { "enabled",  NULL },
-         { NULL, NULL},
+         { NULL,       NULL },
       },
       "disabled"
    },
@@ -122,7 +122,7 @@ struct retro_core_option_definition option_defs_us[] = {
          { "Default (2 Buttons)",  NULL },
          { "CPSF-MD (8 Buttons)",  NULL },
          { "CPSF-SFC (8 Buttons)", NULL },
-         { NULL, NULL},
+         { NULL,                   NULL },
       },
       "Default (2 Buttons)"
    },
@@ -134,9 +134,28 @@ struct retro_core_option_definition option_defs_us[] = {
          { "Default (2 Buttons)",  NULL },
          { "CPSF-MD (8 Buttons)",  NULL },
          { "CPSF-SFC (8 Buttons)", NULL },
-         { NULL, NULL},
+         { NULL,                   NULL },
       },
       "Default (2 Buttons)"
+   },
+   {
+      "px68k_joy1_select",
+      "P1 Joystick Select Mapping",
+      "Assigns a keyboard key to joypad's SELECT button since some games use these keys as the Start or Insect Coin buttons.",
+      {
+         { "Default", NULL },
+         { "XF1",     NULL },
+         { "XF2",     NULL },
+         { "XF3",     NULL },
+         { "XF4",     NULL },
+         { "XF5",     NULL },
+         { "OPT1",    NULL },
+         { "OPT2",    NULL },
+         { "F1",      NULL },
+         { "F2",      NULL },
+         { NULL,      NULL },
+      },
+      "Default"
    },
    {
       "px68k_adpcm_vol",
@@ -159,7 +178,7 @@ struct retro_core_option_definition option_defs_us[] = {
          { "13", NULL },
          { "14", NULL },
          { "15", NULL },
-         { NULL, NULL},
+         { NULL, NULL },
       },
       "15"
    },
@@ -184,7 +203,7 @@ struct retro_core_option_definition option_defs_us[] = {
          { "13", NULL },
          { "14", NULL },
          { "15", NULL },
-         { NULL, NULL},
+         { NULL, NULL },
       },
       "12"
    },
@@ -210,7 +229,7 @@ struct retro_core_option_definition option_defs_us[] = {
          { "13", NULL },
          { "14", NULL },
          { "15", NULL },
-         { NULL, NULL},
+         { NULL, NULL },
       },
       "13"
    },
@@ -222,7 +241,7 @@ struct retro_core_option_definition option_defs_us[] = {
       {
          { "FDD1", NULL },
          { "FDD0", NULL },
-         { NULL, NULL},
+         { NULL,   NULL },
       },
       "FDD1"
    },


### PR DESCRIPTION
- as suggested by jfroco https://github.com/libretro/px68k-libretro/pull/81
"enable mapping of the select key of the joy1 to one of these keys: XF1, XF2, XF3, XF4, XF5, F1 or F2, configurable via Options
This allows to start this games using select key of the joy1:

    Kyuukyoku Tiger (press XF3 to insert coin)
    Parodius Da! (press F1 or F2 to start)"

- modified to match current code base
- also assigns keyboard keys OPT1 and OPT2

details : https://github.com/libretro/px68k-libretro/issues/89
@twinaphex 