### PR TITLE
core updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ px68k-ios/px68k-ios.xcodeproj/xcuserdata
 *.o
 *.so
 *.dll
+libretro/libs
+libretro/obj

--- a/libretro.c
+++ b/libretro.c
@@ -740,6 +740,17 @@ static void update_variables(void)
       else
          Config.joy1_select_mapping = 0;
    }
+
+   var.key = "px68k_disk_path";
+   var.value = NULL;
+
+   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
+   {
+      if (!strcmp(var.value, "disabled"))
+         Config.disk_path = 0;
+      if (!strcmp(var.value, "enabled"))
+         Config.disk_path = 1;
+   }
 }
 
 void update_input(void)
@@ -944,6 +955,10 @@ void retro_init(void)
     struct retro_keyboard_callback cbk = { keyboard_cb };
     environ_cb(RETRO_ENVIRONMENT_SET_KEYBOARD_CALLBACK, &cbk);
 */
+
+   /* set sane defaults */
+   Config.disk_path = 1;
+
    update_variables();
 
    memset(Core_Key_State, 0, 512);

--- a/libretro.c
+++ b/libretro.c
@@ -58,6 +58,7 @@ float FRAMERATE = MODE_HIGH;
 int JOY_TYPE[2] = {0}; /* Set controller type for each player to use */
 int clockmhz = 10;
 DWORD ram_size;
+DWORD libretro_supports_input_bitmasks = 0;
 
 int pauseg = 0;
 
@@ -934,6 +935,10 @@ void retro_init(void)
       exit(0);
    }
 
+   libretro_supports_input_bitmasks = 0;
+   if (environ_cb(RETRO_ENVIRONMENT_GET_INPUT_BITMASKS, NULL))
+      libretro_supports_input_bitmasks = 1;
+
    attach_disk_swap_interface();
 /*
     struct retro_keyboard_callback cbk = { keyboard_cb };
@@ -949,6 +954,7 @@ void retro_deinit(void)
 {
    end_loop_retro();
    p6logd("Retro DeInit\n");
+   libretro_supports_input_bitmasks = 0;
 }
 
 void retro_reset(void)

--- a/libretro/prop.c
+++ b/libretro/prop.c
@@ -300,15 +300,19 @@ void LoadConfig(void)
 		}
 	}
 
-	for (i = 0; i < 2; i++) {
-		sprintf(buf, "FDD%d", i);
-		GetPrivateProfileString(ini_title, buf, "", Config.FDDImage[i], MAX_PATH, winx68k_ini);
-	}
-
-	for (i=0; i<16; i++)
+	if (Config.disk_path)
 	{
-		sprintf(buf, "HDD%d", i);
-		GetPrivateProfileString(ini_title, buf, "", Config.HDImage[i], MAX_PATH, winx68k_ini);
+		for (i = 0; i < 2; i++) {
+			sprintf(buf, "FDD%d", i);
+			GetPrivateProfileString(ini_title, buf, "", Config.FDDImage[i], MAX_PATH, winx68k_ini);
+		}
+
+
+		for (i=0; i<16; i++)
+		{
+			sprintf(buf, "HDD%d", i);
+			GetPrivateProfileString(ini_title, buf, "", Config.HDImage[i], MAX_PATH, winx68k_ini);
+		}
 	}
 
 #if 0
@@ -436,17 +440,20 @@ void SaveConfig(void)
 		}
 	}
 
-	for (i = 0; i < 2; i++)
+	if (Config.disk_path)
 	{
-		/* printf("i: %d", i); */
-		sprintf(buf, "FDD%d", i);
-		WritePrivateProfileString(ini_title, buf, Config.FDDImage[i], winx68k_ini);
-	}
+		for (i = 0; i < 2; i++)
+		{
+			/* printf("i: %d", i); */
+			sprintf(buf, "FDD%d", i);
+			WritePrivateProfileString(ini_title, buf, Config.FDDImage[i], winx68k_ini);
+		}
 
-	for (i=0; i<16; i++)
-	{
-		sprintf(buf, "HDD%d", i);
-		WritePrivateProfileString(ini_title, buf, Config.HDImage[i], winx68k_ini);
+		for (i=0; i<16; i++)
+		{
+			sprintf(buf, "HDD%d", i);
+			WritePrivateProfileString(ini_title, buf, Config.HDImage[i], winx68k_ini);
+		}
 	}
 
 #if 0

--- a/libretro/prop.h
+++ b/libretro/prop.h
@@ -55,6 +55,7 @@ typedef struct
 	BYTE FrameRate;
 	int MenuFontSize; // font size of menu, 0 = normal, 1 = large
 	int joy1_select_mapping; /* used for keyboard to joypad map for P1 Select */
+	int disk_path;
 } Win68Conf;
 
 extern Win68Conf Config;

--- a/libretro_core_options.h
+++ b/libretro_core_options.h
@@ -245,6 +245,17 @@ struct retro_core_option_definition option_defs_us[] = {
       },
       "FDD1"
    },
+   {
+      "px68k_disk_path",
+      "Save Disk Paths",
+      "When enabled, saves the paths of the last loaded disks in drives and auto-loads them on startup. When disabled, FDD and HDD starts empty.",
+      {
+         { "enabled", NULL },
+         { "disabled", NULL },
+         { NULL,   NULL },
+      },
+      "enabled"
+   },
 
    { NULL, NULL, NULL, {{0}}, NULL },
 };


### PR DESCRIPTION
- (readability) descriptive cpu defines so branches specific for CYCLONE CPU and C68K are easily identifiable

- use libretro input bitmasks

- add core option to enable or disable saving disk path. this should prevent FDD drive from booting when user wants to start from a HDD drive
Reference PR, revised to be configurable rather than just disabled:
#58
Other related issues:
#38