### PR TITLE
Move menu items to core options

### DIFF
--- a/libretro.c
+++ b/libretro.c
@@ -751,6 +751,71 @@ static void update_variables(void)
       if (!strcmp(var.value, "enabled"))
          Config.disk_path = 1;
    }
+
+   /* PX68K Menu */
+
+   var.key = "px68k_joy_mouse";
+   var.value = NULL;
+
+   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
+   {
+      /* TODO: Only mouse is implemented */
+      if (!strcmp(var.value, "Joystick"))
+         Config.JoyOrMouse = 0;
+      else if (!strcmp(var.value, "Mouse"))
+         Config.JoyOrMouse = 1;
+   }
+
+   var.key = "px68k_vbtn_swap";
+   var.value = NULL;
+
+   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
+   {
+      if (!strcmp(var.value, "TRIG1 TRIG2"))
+         Config.VbtnSwap = 0;
+      else if (!strcmp(var.value, "TRIG2 TRIG1"))
+         Config.VbtnSwap = 1;
+   }
+
+   var.key = "px68k_no_wait_mode";
+   var.value = NULL;
+
+   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
+   {
+      if (!strcmp(var.value, "disabled"))
+         Config.NoWaitMode = 0;
+      else if (!strcmp(var.value, "enabled"))
+         Config.NoWaitMode = 1;
+   }
+
+   var.key = "px68k_frameskip";
+   var.value = NULL;
+
+   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
+   {
+      if (!strcmp(var.value, "Auto Frame Skip"))
+         Config.FrameRate = 7;
+      else if (!strcmp(var.value, "1/2 Frame"))
+         Config.FrameRate = 2;
+      else if (!strcmp(var.value, "1/3 Frame"))
+         Config.FrameRate = 3;
+      else if (!strcmp(var.value, "1/4 Frame"))
+         Config.FrameRate = 4;
+      else if (!strcmp(var.value, "1/5 Frame"))
+         Config.FrameRate = 5;
+      else if (!strcmp(var.value, "1/6 Frame"))
+         Config.FrameRate = 6;
+      else if (!strcmp(var.value, "1/8 Frame"))
+         Config.FrameRate = 8;
+      else if (!strcmp(var.value, "1/16 Frame"))
+         Config.FrameRate = 16;
+      else if (!strcmp(var.value, "1/32 Frame"))
+         Config.FrameRate = 32;
+      else if (!strcmp(var.value, "1/60 Frame"))
+         Config.FrameRate = 60;
+      else if (!strcmp(var.value, "Full Frame"))
+         Config.FrameRate = 1;
+   }
 }
 
 void update_input(void)

--- a/libretro/windraw.c
+++ b/libretro/windraw.c
@@ -1140,18 +1140,10 @@ int WinDraw_MenuInit(void)
 #include "menu_str_sjis.txt"
 const char menu_item_desc[][60] = {
 	"Reset / NMI reset / Quit",
-	"Select [Virtual Pad / Virtual Mouse]",
 	"Change / Eject floppy 0",
 	"Change / Eject floppy 1",
 	"Change / Eject HDD 0",
-	"Change / Eject HDD 1",
-	"Set frame skip",
-	"Set Sound frequency",
-	"Adjust the size of virtual pad and button",
-	"Change the position of the virtual button",
-	"Configure the pad",
-	"Set No Wait Mode",
-	"Set up JoyKey"
+	"Change / Eject HDD 1"
 };
 
 void WinDraw_DrawMenu(int menu_state, int mkey_pos, int mkey_y, int *mval_y)

--- a/libretro/winui.c
+++ b/libretro/winui.c
@@ -1,4 +1,4 @@
-/* 
+/*
  * Copyright (c) 2003,2008 NONAKA Kimihiro
  * All rights reserved.
  *
@@ -100,32 +100,46 @@ struct menu_flist mfl;
 
 /***** menu items *****/
 
-#define MENU_NUM 13
+#define MENU_NUM 5 //13
 #define MENU_WINDOW 7
 
-int mval_y[] = {0, 0, 0, 0, 0, 0, 0, 0, 2, 1, 0, 1, 1};
+int mval_y[] = {
+	0,
+	0,
+	0,
+	0,
+	0
+};
 
-enum menu_id {M_SYS, M_JOM, M_FD0, M_FD1, M_HD0, M_HD1, M_FS, M_SR, M_VKS, M_VBS, M_HJS, M_NW, M_JK};
+enum menu_id {
+	M_SYS,
+	M_FD0,
+	M_FD1,
+	M_HD0,
+	M_HD1
+};
 
 // Max # of characters is 15.
-char menu_item_key[][15] = {"SYSTEM", "Joy/Mouse", "FDD0", "FDD1", "HDD0", "HDD1", "Frame Skip", "Sound Rate", "VKey Size", "VBtn Swap", "HwJoy Setting", "No Wait Mode", "JoyKey", "uhyo", ""};
+char menu_item_key[][15] = {
+	"SYSTEM",
+	"FDD0",
+	"FDD1",
+	"HDD0",
+	"HDD1",
+	"",
+	"",
+	"uhyo",
+	""
+};
 
 // Max # of characters is 30.
 // Max # of items including terminater `""' in each line is 15.
 char menu_items[][15][30] = {
 	{"RESET", "NMI RESET", "QUIT", ""},
-	{"Joystick", "Mouse", ""},
 	{"dummy", "EJECT", ""},
 	{"dummy", "EJECT", ""},
 	{"dummy", "EJECT", ""},
-	{"dummy", "EJECT", ""},
-	{"Auto Frame Skip", "Full Frame", "1/2 Frame", "1/3 Frame", "1/4 Frame", "1/5 Frame", "1/6 Frame", "1/8 Frame", "1/16 Frame", "1/32 Frame", "1/60 Frame", ""},
-	{"No Sound", "11025Hz", "22050Hz", "44100Hz", "48000Hz", ""},
-	{"Ultra Huge", "Super Huge", "Huge", "Large", "Medium", "Small", ""},
-	{"TRIG1 TRIG2", "TRIG2 TRIG1", ""},
-	{"Axis0: xx", "Axis1: xx", "Hat: xx", "Button0: xx", "Button1: xx",  ""},
-	{"Off", "On", ""},
-	{"Off", "On", ""}
+	{"dummy", "EJECT", ""}
 };
 
 static void menu_system(int v);
@@ -145,19 +159,11 @@ struct _menu_func {
 };
 
 struct _menu_func menu_func[] = {
-	{menu_system, 0}, 
-	{menu_joy_or_mouse, 1},
+	{menu_system, 0},
 	{menu_create_flist, 0},
 	{menu_create_flist, 0},
 	{menu_create_flist, 0},
-	{menu_create_flist, 0},
-	{menu_frame_skip, 1},
-	{menu_sound_rate, 1},
-	{menu_vkey_size, 1},
-	{menu_vbtn_swap, 1},
-	{menu_hwjoy_setting, 0},
-	{menu_nowait, 1},
-	{menu_joykey, 1}
+	{menu_create_flist, 0}
 };
 
 int WinUI_get_drv_num(int key)
@@ -175,7 +181,7 @@ int WinUI_get_drv_num(int key)
 
 static void menu_hwjoy_print(int v)
 {
-	if (v <= 1) {
+	/*if (v <= 1) {
 		sprintf(menu_items[M_HJS][v], "Axis%d(%s): %d",
 			v,
 			(v == 0)? "Left/Right" : "Up/Down",
@@ -186,7 +192,7 @@ static void menu_hwjoy_print(int v)
 		sprintf(menu_items[M_HJS][v], "Button%d: %d",
 			v - 3,
 			Config.HwJoyBtn[v - 3]);
-	}
+	}*/
 }
 
 /******************************************************************************
@@ -197,44 +203,9 @@ WinUI_Init(void)
 {
 	int i;
 
-	mval_y[M_JOM] = Config.JoyOrMouse;
-	if (Config.FrameRate == 7) {
-		mval_y[M_FS] = 0;
-	} else if (Config.FrameRate == 8) {
-		mval_y[M_FS] = 7;
-	} else if (Config.FrameRate == 16) {
-		mval_y[M_FS] = 8;
-	} else if (Config.FrameRate == 32) {
-		mval_y[M_FS] = 9;
-	} else if (Config.FrameRate == 60) {
-		mval_y[M_FS] = 10;
-	} else {
-		mval_y[M_FS] = Config.FrameRate;
-	}
-
-	if (Config.SampleRate == 0) {
-		mval_y[M_SR] = 0;
-	} else if (Config.SampleRate == 11025) {
-		mval_y[M_SR] = 1;
-	} else if (Config.SampleRate == 22050) {
-		mval_y[M_SR] = 2;
-	} else if (Config.SampleRate == 44100) {
-		mval_y[M_SR] = 3;
-	} else if (Config.SampleRate == 48000) {
-		mval_y[M_SR] = 4;
-	} else {
-		mval_y[M_SR] = 1;
-	}
-
-	mval_y[M_VKS] = Config.VkeyScale;
-	mval_y[M_VBS] = Config.VbtnSwap;
-
 	for (i = 0; i < 11; i++) {
 		menu_hwjoy_print(i);
 	}
-
-	mval_y[M_NW] = Config.NoWaitMode;
-	mval_y[M_JK] = Config.JoyKey;
 
 #if defined(ANDROID)
 #define CUR_DIR_STR winx68k_dir
@@ -834,7 +805,7 @@ int WinUI_Menu(int first)
 			drv = WinUI_get_drv_num(mkey_y);
 			p6logd("***** drv:%d *****\n", drv);
 			if (drv < 0) {
-				break; 
+				break;
 			}
 			y = mfl.ptr + mfl.y;
 			// file loaded

--- a/libretro_core_options.h
+++ b/libretro_core_options.h
@@ -250,14 +250,69 @@ struct retro_core_option_definition option_defs_us[] = {
       "Save Disk Paths",
       "When enabled, saves the paths of the last loaded disks in drives and auto-loads them on startup. When disabled, FDD and HDD starts empty.",
       {
-         { "enabled", NULL },
+         { "enabled",  NULL },
          { "disabled", NULL },
-         { NULL,   NULL },
+         { NULL,       NULL },
       },
       "enabled"
    },
 
-   { NULL, NULL, NULL, {{0}}, NULL },
+   /* from PX68K Menu */
+   {
+      "px68k_joy_mouse",
+      "Joy/Mouse",
+      "Select [Mouse] or [Joypad] to controls in-game mouse pointer.",
+      {
+         { "Mouse",    NULL},
+         { "Joystick", NULL}, /* unimplemented yet */
+         { NULL,       NULL },
+      },
+      "Mouse"
+   },
+   {
+      "px68k_vbtn_swap",
+      "VBtn Swap",
+      "When set to [enabled], swaps TRIG1 and TRIG2 buttons when a 2-button gamepad is selected.",
+      {
+         { "TRIG1 TRIG2", NULL},
+         { "TRIG2 TRIG1", NULL},
+         { NULL,          NULL },
+      },
+      "TRIG1 TRIG2"
+   },
+   {
+      "px68k_no_wait_mode",
+      "No Wait Mode",
+      "When set to [enabled], core runs as fast as possible. Can cause audio dysnc but useful if using fast-forward. Setting this [disabled] is recommended.",
+      {
+         { "disabled", NULL},
+         { "enabled",  NULL},
+         { NULL,       NULL },
+      },
+      "disabled"
+   },
+   {
+      "px68k_frameskip",
+      "Frames Skip",
+      "Choose how much frames should be skipped to improve performance at the expense of visual smoothness.",
+      {
+         { "Full Frame",      NULL },
+         { "1/2 Frame",       NULL },
+         { "1/3 Frame",       NULL },
+         { "1/4 Frame",       NULL },
+         { "1/5 Frame",       NULL },
+         { "1/6 Frame",       NULL },
+         { "1/8 Frame",       NULL },
+         { "1/16 Frame",      NULL },
+         { "1/32 Frame",      NULL },
+         { "1/60 Frame",      NULL },
+         { "Auto Frame Skip", NULL },
+         { NULL,   NULL },
+      },
+      "Full Frame"
+   },
+
+   { NULL, NULL, NULL, {{0}}, NULL }
 };
 
 /*


### PR DESCRIPTION
Items moved to core options:
- Frame Skip
- Joy/Mouse (mouse mode only works)
- Vbtn Swap
- No Wait Mode

Items that are disabled or removed, either because its not needed or its only using set-once option
- Sound Rate - fixed to 44100
- VKey Size - we dont use virtual keys
- HwJoy Setting - button mappings
- JoyKey, which is suppose to allow controlling gamepad buttons using a keyboard. Its not necessary in a libretro port due to how keyboard and joypad inputs already works.
