### PR TITLE
Fix Joy/Mouse core option's incorrect behavior

### DIFF
--- a/libretro.c
+++ b/libretro.c
@@ -764,11 +764,14 @@ static void update_variables(void)
 
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
    {
-      /* TODO: Only mouse is implemented */
+      int value = 0;
       if (!strcmp(var.value, "Joystick"))
-         Config.JoyOrMouse = 0;
+         value = 0;
       else if (!strcmp(var.value, "Mouse"))
-         Config.JoyOrMouse = 1;
+         value = 1;
+
+      Config.JoyOrMouse = value;
+      Mouse_StartCapture(value == 1);
    }
 
    var.key = "px68k_vbtn_swap";


### PR DESCRIPTION
- When option is set to "Joystick", the game should not respond to any more
  mouse inputs. This is not the case due to a missing call to Mouse_StartCapture()
- From what i understand about this option, when "Joystick" is selected,
  only joystick input would register with compatible games. When
  "Mouse" is selected, both mouse and joystick inputs are registered to the game
  (e.g. Granada).
  Removing comment based on better understanding.