### PR TITLE
Fix Disk Control not ejecting correctly for .m3u

### DIFF
--- a/libretro.c
+++ b/libretro.c
@@ -86,7 +86,7 @@ bool set_eject_state(bool ejected)
    if (ejected)
    {
       FDD_EjectFD(disk_drive);
-		Config.FDDImage[disk_drive][0] = '\0';
+      Config.FDDImage[disk_drive][0] = '\0';
    }
    disk_inserted = !ejected;
    return true;

--- a/libretro.c
+++ b/libretro.c
@@ -83,6 +83,11 @@ unsigned disk_drive = 1;
 
 bool set_eject_state(bool ejected)
 {
+   if (ejected)
+   {
+      FDD_EjectFD(disk_drive);
+		Config.FDDImage[disk_drive][0] = '\0';
+   }
    disk_inserted = !ejected;
    return true;
 }


### PR DESCRIPTION
- When ejecting disk from disk control option, the signal is only sent to frontend and core does not
  eject the disk when it should causing problems to some games that require only one disk to be inserted.

Reference issue: https://github.com/libretro/px68k-libretro/issues/98