### PR TITLE
Use -O2 optimization

### DIFF
--- a/Makefile.libretro
+++ b/Makefile.libretro
@@ -369,7 +369,7 @@ ifeq ($(DEBUG), 1)
 else ifneq (,$(findstring msvc,$(platform)))
    FLAGS += -O2
 else
-   FLAGS += -O3 -ffast-math -fomit-frame-pointer
+   FLAGS += -O2 -ffast-math -fomit-frame-pointer
 endif
 
 LDFLAGS +=  $(fpic) $(SHARED) $(EXTRA_LDF)


### PR DESCRIPTION
Platform-defines uses -O2, but later on is overwritten with -O3. So
which one should be used?
PR changes this to use -O2 by default. Its faster at about 1-minute less
than using -O3 anyways so that probably means something.