### PR TITLE
win32: Fix instruments not initializing (kinda)

### DIFF
--- a/libretro.c
+++ b/libretro.c
@@ -294,7 +294,6 @@ void midi_out_short_msg(size_t msg)
       midi_cb.write(msg         & 0xFF, 0); /* status byte */
       midi_cb.write((msg >> 8)  & 0xFF, 0); /* note no. */
       midi_cb.write((msg >> 16) & 0xFF, 0); /* velocity */
-      midi_cb.write((msg >> 24) & 0xFF, 0); /* none */
    }
 }
 


### PR DESCRIPTION
This should be enough of a fix. but the winmm midi driver appears to behave differently (maybe incorrectly) to initialize SC-55 and MT-32 properly.

SC-55 for example will have missing pitch/bend effects ans sometimes will hold notes longer than it should. in MT-32 it totally does not set some instruments properly. This issue is only a problem with using windows midi driver using the libretro API. Linux implementation works fine for the most part.

In anycase, short msg write should only be 3 bytes (suppose to be 2 bytes for midi status 0xC0 and 0xD0 but api does not like shorter than 3 writes) so this PR is still valid.